### PR TITLE
Add SWIG wrapper and test for configObj

### DIFF
--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -260,9 +260,11 @@ typedef struct {
 %include "../../mapsymbol.h"
 %include "../../maphash.h"
 %include "../../maperror.h"
+%include "../../mapserv-config.h"
 
 %apply Pointer NONNULL { mapObj *map };
 %apply Pointer NONNULL { layerObj *layer };
+%apply Pointer NONNULL { configObj *config };
 
 /* 
 =============================================================================
@@ -270,7 +272,6 @@ typedef struct {
 =============================================================================
 */
 
-%include "../swiginc/config.i"
 %include "../swiginc/error.i"
 %include "../swiginc/map.i"
 %include "../swiginc/mapzoom.i"
@@ -303,6 +304,7 @@ typedef struct {
 %include "../swiginc/legend.i"
 %include "../swiginc/referencemap.i"
 %include "../swiginc/querymap.i"
+%include "../swiginc/config.i"
 
 /* 
 =============================================================================

--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -269,7 +269,8 @@ typedef struct {
  Class extension methods are now included from separate interface files  
 =============================================================================
 */
-   
+
+%include "../swiginc/config.i"
 %include "../swiginc/error.i"
 %include "../swiginc/map.i"
 %include "../swiginc/mapzoom.i"

--- a/mapscript/python/tests/cases/config_test.py
+++ b/mapscript/python/tests/cases/config_test.py
@@ -38,5 +38,26 @@ class ConfigConstructorTestCase(unittest.TestCase):
         assert test_config.thisown == 1
 
 
+class ConfigHashTableTests(MapTestCase):
+
+    def testGetEnv(self):
+
+        test_config = mapscript.configObj(TESTCONFIGFILE)
+        assert test_config.env.__class__.__name__ == "hashTableObj"
+        assert test_config.env.numitems == 1
+
+    def testGetMaps(self):
+
+        test_config = mapscript.configObj(TESTCONFIGFILE)
+        assert test_config.maps.__class__.__name__ == "hashTableObj"
+        assert test_config.maps.numitems == 0
+
+    def testGetMaps(self):
+
+        test_config = mapscript.configObj(TESTCONFIGFILE)
+        assert test_config.plugins.__class__.__name__ == "hashTableObj"
+        assert test_config.plugins.numitems == 0
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/mapscript/python/tests/cases/config_test.py
+++ b/mapscript/python/tests/cases/config_test.py
@@ -33,7 +33,7 @@ class ConfigConstructorTestCase(unittest.TestCase):
 
     def testConfigConstructorFilenameArg(self):
         """ConfigConstructorTestCase.testConfigConstructorFilenameArg: map constructor with filename argument"""
-        test_config = mapscript.mapObj(TESTCONFIGFILE)
+        test_config = mapscript.configObj(TESTCONFIGFILE)
         assert test_config.__class__.__name__ == "configObj"
         assert test_config.thisown == 1
 

--- a/mapscript/python/tests/cases/config_test.py
+++ b/mapscript/python/tests/cases/config_test.py
@@ -1,0 +1,42 @@
+# Project:  MapServer
+# Purpose:  xUnit style Python mapscript tests of Map
+# Author:   Seth Girvin, sgirvin@geographika.co.uk
+#
+# ===========================================================================
+# Copyright (c) 2021, MapServer team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+# ===========================================================================
+
+import unittest
+import mapscript
+from .testing import MapTestCase, TESTCONFIGFILE
+
+
+class ConfigConstructorTestCase(unittest.TestCase):
+
+    def testConfigConstructorFilenameArg(self):
+        """ConfigConstructorTestCase.testConfigConstructorFilenameArg: map constructor with filename argument"""
+        test_config = mapscript.mapObj(TESTCONFIGFILE)
+        assert test_config.__class__.__name__ == "configObj"
+        assert test_config.thisown == 1
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mapscript/python/tests/cases/config_test.py
+++ b/mapscript/python/tests/cases/config_test.py
@@ -38,7 +38,7 @@ class ConfigConstructorTestCase(unittest.TestCase):
         assert test_config.thisown == 1
 
 
-class ConfigHashTableTests(MapTestCase):
+class ConfigHashTableTests(unittest.TestCase):
 
     def testGetEnv(self):
 
@@ -52,7 +52,7 @@ class ConfigHashTableTests(MapTestCase):
         assert test_config.maps.__class__.__name__ == "hashTableObj"
         assert test_config.maps.numitems == 0
 
-    def testGetMaps(self):
+    def testGetPlugins(self):
 
         test_config = mapscript.configObj(TESTCONFIGFILE)
         assert test_config.plugins.__class__.__name__ == "hashTableObj"

--- a/mapscript/python/tests/cases/config_test.py
+++ b/mapscript/python/tests/cases/config_test.py
@@ -26,7 +26,7 @@
 
 import unittest
 import mapscript
-from .testing import MapTestCase, TESTCONFIGFILE
+from .testing import TESTCONFIGFILE
 
 
 class ConfigConstructorTestCase(unittest.TestCase):

--- a/mapscript/python/tests/cases/testing.py
+++ b/mapscript/python/tests/cases/testing.py
@@ -38,7 +38,7 @@ import mapscript
 
 # define the path to mapserver test data
 TESTS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
-TESTMAPFILE = os.path.join(TESTS_PATH, 'test.map')
+TESTMAPFILE = os.path.join(TESTS_PATH, 'mapserver-sample.conf')
 TESTCONFIGFILE = os.path.join(TESTS_PATH, 'test.map')
 XMARKS_IMAGE = os.path.join(TESTS_PATH, 'xmarks.png')
 HOME_IMAGE = os.path.join(TESTS_PATH, 'home.png')

--- a/mapscript/python/tests/cases/testing.py
+++ b/mapscript/python/tests/cases/testing.py
@@ -38,8 +38,8 @@ import mapscript
 
 # define the path to mapserver test data
 TESTS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
-TESTMAPFILE = os.path.join(TESTS_PATH, 'mapserver-sample.conf')
-TESTCONFIGFILE = os.path.join(TESTS_PATH, 'test.map')
+TESTMAPFILE = os.path.join(TESTS_PATH, 'test.map')
+TESTCONFIGFILE = os.path.join(TESTS_PATH, 'mapserver-sample.conf')
 XMARKS_IMAGE = os.path.join(TESTS_PATH, 'xmarks.png')
 HOME_IMAGE = os.path.join(TESTS_PATH, 'home.png')
 TEST_IMAGE = os.path.join(TESTS_PATH, 'test.png')

--- a/mapscript/python/tests/cases/testing.py
+++ b/mapscript/python/tests/cases/testing.py
@@ -39,6 +39,7 @@ import mapscript
 # define the path to mapserver test data
 TESTS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
 TESTMAPFILE = os.path.join(TESTS_PATH, 'test.map')
+TESTCONFIGFILE = os.path.join(TESTS_PATH, 'test.map')
 XMARKS_IMAGE = os.path.join(TESTS_PATH, 'xmarks.png')
 HOME_IMAGE = os.path.join(TESTS_PATH, 'home.png')
 TEST_IMAGE = os.path.join(TESTS_PATH, 'test.png')

--- a/mapscript/swiginc/config.i
+++ b/mapscript/swiginc/config.i
@@ -1,0 +1,39 @@
+/* ===========================================================================
+   Project:  MapServer
+   Purpose:  SWIG interface file for mapscript configObj extensions
+   Author:   Steve Lime 
+             Seth Girvin, sgirvin@geographika.co.uk
+             
+   ===========================================================================
+   Copyright (c) 1996-2021 Regents of the University of Minnesota.
+   
+   Permission is hereby granted, free of charge, to any person obtaining a
+   copy of this software and associated documentation files (the "Software"),
+   to deal in the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+ 
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+ 
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ===========================================================================
+*/
+
+%extend configObj 
+{
+
+    /// Create a new instance of :class:`configObj`
+    configObj(char *filename="")
+    {
+        return msLoadConfig(filename);
+    }
+
+}

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -40,11 +40,21 @@
         }      
     }
 
-#ifdef SWIGCSHARP      
-    mapObj(char *mapText, int isMapText /*used as signature only to differentiate this constructor from default constructor*/ ) 
-    {
-        return msLoadMapFromString(mapText, NULL);
-    }
+#ifdef SWIGCSHARP
+
+  mapObj(char *filename) 
+  {
+        if (filename && strlen(filename))
+            return msLoadMap(filename, NULL, NULL);
+        else { /* create an empty map, no layers etc... */
+            return msNewMapObj();
+        } 
+  }
+
+  mapObj(char *mapText, int isMapText /*used as signature only to differentiate this constructor from default constructor*/ ) 
+  {
+      return msLoadMapFromString(mapText, NULL);
+  }
 #endif 
     
     ~mapObj() 

--- a/mapserv-config.cpp
+++ b/mapserv-config.cpp
@@ -78,13 +78,15 @@ static int loadConfig(configObj *config)
   }
 }
 
-configObj *msLoadConfig()
+configObj *msLoadConfig(char* ms_config_file)
 {
   configObj *config = NULL;
-  static char *ms_config_file = NULL;
 
-  // get config filename from environment
-  ms_config_file = getenv("MAPSERVER_CONFIG_FILE");
+  if (ms_config_file == NULL) {
+    // get config filename from environment
+    ms_config_file = getenv("MAPSERVER_CONFIG_FILE");
+  }
+
   if(ms_config_file == NULL) {
     msSetError(MS_MISCERR, "No config file set.", "msLoadConfig()");
     return NULL;

--- a/mapserv-config.h
+++ b/mapserv-config.h
@@ -9,10 +9,13 @@ extern "C" {
 
 enum MS_CONFIG_SECTIONS { MS_CONFIG_SECTION=3000, MS_CONFIG_SECTION_ENV, MS_CONFIG_SECTION_MAPS, MS_CONFIG_SECTION_PLUGINS };
 
+/**
+The :ref:`CONFIG <config>` object
+*/
 typedef struct {
-  hashTableObj env;
-  hashTableObj maps;
-  hashTableObj plugins;
+  hashTableObj env; ///< Key-value pairs of environment variables and values
+  hashTableObj maps; ///< Key-value pairs of Mapfile names and paths
+  hashTableObj plugins; ///< Key-value pairs of plugin names and paths
 } configObj;
 
 MS_DLL_EXPORT configObj *msLoadConfig(char* ms_config_file);

--- a/mapserv-config.h
+++ b/mapserv-config.h
@@ -17,7 +17,7 @@ typedef struct {
 } configObj;
 #endif /*SWIG*/
 
-MS_DLL_EXPORT configObj *msLoadConfig();
+MS_DLL_EXPORT configObj *msLoadConfig(char* ms_config_file);
 MS_DLL_EXPORT void msFreeConfig(configObj *config);
 MS_DLL_EXPORT const char *msConfigGetEnv(configObj *config, const char *key);
 MS_DLL_EXPORT const char *msConfigGetMap(configObj *config, const char *key);

--- a/mapserv-config.h
+++ b/mapserv-config.h
@@ -9,13 +9,11 @@ extern "C" {
 
 enum MS_CONFIG_SECTIONS { MS_CONFIG_SECTION=3000, MS_CONFIG_SECTION_ENV, MS_CONFIG_SECTION_MAPS, MS_CONFIG_SECTION_PLUGINS };
 
-#ifndef SWIG
 typedef struct {
   hashTableObj env;
   hashTableObj maps;
   hashTableObj plugins;
 } configObj;
-#endif /*SWIG*/
 
 MS_DLL_EXPORT configObj *msLoadConfig(char* ms_config_file);
 MS_DLL_EXPORT void msFreeConfig(configObj *config);

--- a/mapserv.c
+++ b/mapserv.c
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
   mapservObj  *mapserv = NULL;
   configObj *config = NULL;
 
-  config = msLoadConfig(); // is the right spot to do this?
+  config = msLoadConfig(NULL); // is the right spot to do this?
   if(config == NULL) {
     msCGIWriteError(mapserv);
     exit(0);

--- a/mapservutil.c
+++ b/mapservutil.c
@@ -1869,7 +1869,7 @@ int msCGIHandler(const char *query_string, void **out_buffer, size_t *buffer_len
     goto end_request;
   }
 
-  config = msLoadConfig();
+  config = msLoadConfig(NULL);
   if(config == NULL) {
     msCGIWriteError(mapserv);
     goto end_request;

--- a/tests/mapserver-sample.conf
+++ b/tests/mapserver-sample.conf
@@ -1,0 +1,48 @@
+#
+# Sample MapServer 8.0 Config File
+#
+CONFIG
+
+  #
+  # Environment variables (see https://mapserver.org/environment_variables.html)
+  #
+  ENV
+    #
+    # Limit Mapfile Access
+    #
+    # MS_MAP_NO_PATH "1"
+    MS_MAP_PATTERN "^/opt/mapserver" ## required
+
+    #
+    # Global Log/Debug Setup
+    #
+    # MS_DEBUGLEVEL "5"
+    # MS_ERRORFILE "/opt/mapserver/logs/mapserver.log"
+
+    #
+    # Default Map
+    #
+    # MS_MAPFILE "/opt/mapserver/test/test.map"
+
+    #
+    # Other Options
+    #
+    # MS_ENCRYPTION_KEY
+    # MS_USE_GLOBAL_FT_CACHE
+    # MS_PDF_CREATION_DATE
+    # MS_MAPFILE_PATTERN "\.map$"
+    # MS_XMLMAPFILE_XSLT
+    # MS_MODE
+    # MS_OPENLAYERS_JS_URL
+    # MS_TEMPPATH
+    # MS_MAX_OPEN_FILES 
+  END
+ 
+  #
+  # Map aliases
+  #
+  MAPS
+    # TEST_MAPFILE "/opt/mapserver/test/test.map"
+  END
+
+END


### PR DESCRIPTION
This pull request also changes the loading function to allow a filename to be passed in directly to bypass using an environment variable: `onfigObj *msLoadConfig(char* ms_config_file)`

This allows the `configObj` to be created in MapScript without setting an environ variable for easier testing. 

Also would it make sense to move `etc/mapserver-sample.conf` to `tests/mapserver-sample.conf` in the same location as the test/sample Mapfile? If not I could include a copy for testing. 