### PR TITLE
Add error checks and avoid NULLs for some layer items

### DIFF
--- a/mapogcapi.cpp
+++ b/mapogcapi.cpp
@@ -573,7 +573,7 @@ static const char* getCollectionDescription(layerObj* layer)
 static const char* getCollectionTitle(layerObj* layer)
 {
     const char* title = msOWSLookupMetadata(&(layer->metadata), "AOF", "title");
-    if(!title) title = "";
+    if(!title) title = layer->name; // revert to layer name if no title found
     return title;
 }
 
@@ -1189,7 +1189,7 @@ static int processCollectionItemsRequest(mapObj *map, cgiRequestObj *request, co
 
   // extend the response a bit for templating (HERE)
   if(format == OGCAPIFormat::HTML) {
-    const char *title = msOWSLookupMetadata(&(layer->metadata), "AOF", "title");
+    const char *title = getCollectionTitle(layer);
     const char *id = layer->name;
     response["collection"] = {
       { "id", id },

--- a/mapogcapi.cpp
+++ b/mapogcapi.cpp
@@ -566,12 +566,15 @@ static const char* getCollectionDescription(layerObj* layer)
 {
   const char *description = msOWSLookupMetadata(&(layer->metadata), "A", "description");
   if(!description) description = msOWSLookupMetadata(&(layer->metadata), "OF", "abstract"); // fallback on abstract
+  if(!description) description = "";
   return description;
 }
 
 static const char* getCollectionTitle(layerObj* layer)
 {
-  return msOWSLookupMetadata(&(layer->metadata), "AOF", "title");
+    const char* title = msOWSLookupMetadata(&(layer->metadata), "AOF", "title");
+    if(!title) title = "";
+    return title;
 }
 
 static int getGeometryPrecision(mapObj *map, layerObj *layer)
@@ -724,6 +727,11 @@ static void outputTemplate(const char *directory, const char *filename, const js
   } catch(const inja::RenderError &e) {
     outputError(OGCAPI_CONFIG_ERROR, "Template rendering error. " + std::string(e.what()) + " (" + std::string(filename) + ").");
     return;
+  }
+    catch (const inja::InjaError& e) {
+        outputError(OGCAPI_CONFIG_ERROR, "InjaError error. " + std::string(e.what()) + " (" + std::string(filename) + ")."
+            + " (" + std::string(directory) + ").");
+        return;
   } catch(...) {
     outputError(OGCAPI_SERVER_ERROR, "General template handling error.");
     return;


### PR DESCRIPTION
This adds additional logging to help find any issues with `oga_html_template_directory` access/path. 

Also fixes HTTP 500 errros caused by NULL metadata values in layers when accessing `ogcapi/collections?f=html`
Reverts to LAYER->NAME if no metadata ows_title set (alternate option is an empty string or warning?). 
