### PR TITLE
Update mssql tests to use config plugin

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -4281,11 +4281,12 @@ int loadLayer(layerObj *layer, mapObj *map)
 
 	  if(getString(&value) == MS_FAILURE) return(-1);
           plugin_library = msConfigGetPlugin(map->config, value);
-          free(value);
           if(!plugin_library) {
-            msSetError(MS_MISCERR, "Plugin value not found in config file." , "loadLayer()");
+            msSetError(MS_MISCERR, "Plugin value \"%s\" not found in config file." , "loadLayer()", value);
+            free(value);
             return(-1);
           }
+          free(value);
           layer->plugin_library_original = strdup(plugin_library);
 	} else {
           if(getString(&layer->plugin_library_original) == MS_FAILURE) return(-1);

--- a/msautotest/etc/mapserv.conf
+++ b/msautotest/etc/mapserv.conf
@@ -2,4 +2,8 @@ CONFIG
   ENV
     MS_MAP_PATTERN "."
   END
+  # following used by the mssql tests on Appveyor
+  PLUGINS
+    "mssql" "C:\projects\mapserver\build\Release\msplugin_mssql2008.dll"
+  END
 END

--- a/msautotest/mssql/include/mssql_connection.map
+++ b/msautotest/mssql/include/mssql_connection.map
@@ -1,4 +1,4 @@
   CONNECTIONTYPE PLUGIN
-  PLUGIN "C:\projects\mapserver\build\Release\msplugin_mssql2008.dll"
+  PLUGIN "mssql"
   CONNECTION "SERVER=(local)\SQL2019;DATABASE=msautotest;uid=sa;pwd=Password12!;"
   STATUS OFF

--- a/shp2img.c
+++ b/shp2img.c
@@ -38,6 +38,7 @@ int main(int argc, char *argv[])
 
   mapObj         *map=NULL;
   imageObj         *image = NULL;
+  configObj* config = NULL;
 
   char **layers=NULL;
   int num_layers=0;
@@ -123,10 +124,12 @@ int main(int argc, char *argv[])
       exit(1);
     }
 
+    config = msLoadConfig(NULL);
+
     for(i=1; i<argc; i++) { /* Step though the user arguments, 1st to find map file */
 
       if(strcmp(argv[i],"-m") == 0) {
-        map = msLoadMap(argv[i+1], NULL, NULL);
+        map = msLoadMap(argv[i+1], NULL, config);
         if(!map) {
           msWriteError(stderr);
           msCleanup();
@@ -298,6 +301,7 @@ int main(int argc, char *argv[])
 
       msFreeMap(map);
       msCleanup();
+      msFreeConfig(config);
       exit(1);
     }
 
@@ -317,5 +321,6 @@ int main(int argc, char *argv[])
 
   } /*   for(draws=0; draws<iterations; draws++) { */
   msCleanup();
+  msFreeConfig(config);
   return(0);
 } /* ---- END Main Routine ---- */


### PR DESCRIPTION
This also requires shp2img to load the config file. 
In addition any missing plugin key is output as part of the error message. 